### PR TITLE
Feature/add-pull-request-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+<!--
+    Before submitting a Pull Request, please ensure you've done the following:
+     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
+        - If the change needs to be large, set up a meeting with reviewers to walk through the code.
+     - ✅ Provide tests for your changes.
+     - 📝 Use descriptive commit messages.
+     - 📗 Update any related documentation and include any relevant screenshots.
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] Refactor
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Optimization
+- [ ] Documentation Update
+
+## Description
+
+_Give a brief context and description of the code change. Highlight anything you want reviewers to pay attention to._
+
+_The PR should have enough information so someone coming in fresh gets a sense of what's going on, but the details of the overall project can be documented on project.digitalaidseattle.org_
+
+## Related Tickets & Documents
+
+_Link user story from projects.digitalaidseattle.org_
+
+- Related Issue #
+- Closes #
+
+## QA Instructions, Screenshots, Recordings
+
+_Please replace this line with instructions on how to test your changes, as well as any relevant images for UI changes._
+
+### UI accessibility checklist
+_If your PR includes UI changes, please utilize this checklist:_
+- [ ] Semantic HTML implemented?
+- [ ] Keyboard operability supported?
+- [ ] Color contrast tested?
+
+## Added/updated tests?
+_We are aiming for 100% statement coverage._
+
+- [ ] Yes
+- [ ] No, and this is why: _please replace this line with details on why tests
+      have not been included_
+- [ ] I need help with writing tests
+
+## [optional] Are there any post-deployment tasks we need to perform?
+
+## [optional] What gif best describes this PR or how it makes you feel?
+
+![alt_text](gif_link)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Following up from a conversation about PR templates during standup, this code change just adds a template. I did what I could to modify [this](https://github.com/forem/forem/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1) template to align with [this](https://docs.google.com/document/d/1o7Ve4CGwCQwzXCaDuD2aF6ZW6AJ0IF2RfHP--Li9jCU/edit) internal methodology document, but I imagine this is just the first version of the template and I am open to any changes.

## Related Tickets & Documents

None

## QA Instructions, Screenshots, Recordings

I when creating a pull request with this GitHub file in the .github folder, the PR template auto populates. Pretty cool!

## Added/updated tests?

NA

## Are there any post-deployment tasks we need to perform?

This will need to be merged into the default branch before it will automatically work.

According to the documentation, "[you must create templates on the repository's default branch](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates)". I could submit this to the default branch, but I think I'll just wait till the end of the sprint for this to merge, I don't want to mess with the merge process we have in place.