### PR TITLE
Features/1.2.2.10/input-form-read

### DIFF
--- a/__tests__/layout/AppMenu.test.tsx
+++ b/__tests__/layout/AppMenu.test.tsx
@@ -93,6 +93,7 @@ describe('Menu Items Check', () => {
         <ServiceRequestDialog
           visible={dialog === 'newServiceRequest'}
           onClose={onClose}
+          ticketId=""
         />
       </LayoutContext.Provider>,
     );

--- a/__tests__/layout/AppMenu.test.tsx
+++ b/__tests__/layout/AppMenu.test.tsx
@@ -59,6 +59,10 @@ const layoutContextValue = {
 };
 
 jest.mock('next/router', () => jest.requireActual('next-router-mock'));
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
+}));
 jest.mock('src/hooks/useAppConstants');
 jest.mock('src/hooks/useTeamMembers');
 

--- a/__tests__/layout/AppTopbar.test.tsx
+++ b/__tests__/layout/AppTopbar.test.tsx
@@ -51,6 +51,10 @@ const layoutContextValue = {
 };
 
 jest.mock('next/router', () => jest.requireActual('next-router-mock'));
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
+}));
 
 describe('Navigation/Menu Top Bar - Href Checks', () => {
   test('Animal button has correct href attribute', () => {

--- a/__tests__/src/components/serviceRequest/ServiceRequestDialog.test.tsx
+++ b/__tests__/src/components/serviceRequest/ServiceRequestDialog.test.tsx
@@ -5,6 +5,8 @@ import ServiceRequestDialog from '@components/serviceRequest/ServiceRequestDialo
 import { defaultClientInformation } from '@context/serviceRequest/clientInformationContext';
 import { defaultPetInformation } from '@context/serviceRequest/petInformationContext';
 import { defaultServiceInformation } from '@context/serviceRequest/serviceInformationContext';
+import { mockAnimal, mockClient, mockTicket } from '@hooks/__mocks__/useTicketById';
+import useTicketById from '@hooks/useTicketById';
 import '@testing-library/jest-dom';
 import {
   fireEvent, render, screen, waitFor,
@@ -23,8 +25,9 @@ jest.mock('src/services/ClientService', () => {
   };
 });
 
+jest.mock('src/hooks/useTicketById');
+const mockUseTicketById = jest.mocked(useTicketById);
 jest.mock('src/hooks/useAppConstants');
-
 jest.mock('src/hooks/useTeamMembers');
 
 const SaveCancelLabels = {
@@ -40,15 +43,15 @@ const labelsOfFormFieldsToTest = [
 const testId = 'serviceRequestDialog';
 describe('ServiceRequestDialog', () => {
   const mockOnClose = jest.fn();
-  function PageComponent({ showOnOpen }) {
+  function PageComponent({ showOnOpen, ticketId }) {
     const [visible, setVisible] = useState(showOnOpen);
     mockOnClose.mockImplementation(() => setVisible(false));
-    return <ServiceRequestDialog visible={visible} onClose={mockOnClose} />;
+    return <ServiceRequestDialog ticketId={ticketId} visible={visible} onClose={mockOnClose} />;
   }
 
-  function setup(showOnOpen = false) {
+  function setup(showOnOpen = false, ticketId = null) {
     render(
-      <PageComponent showOnOpen={showOnOpen} />,
+      <PageComponent showOnOpen={showOnOpen} ticketId={ticketId} />,
     );
   }
 
@@ -120,9 +123,9 @@ describe('ServiceRequestDialog', () => {
 
   it('should debounce calls to save', async () => {
     /*
-    * Note the FormConfirmationButtons' Save button *should* prevent multiple clicks when the form is busy
-    * but in case that changes in the future, the form should still debouce the save
-    */
+      * Note the FormConfirmationButtons' Save button *should* prevent multiple clicks when the form is busy
+      * but in case that changes in the future, the form should still debouce the save
+      */
     //* Arrange
     let resolve;
     clientService.newRequest = jest.fn()
@@ -156,5 +159,35 @@ describe('ServiceRequestDialog', () => {
     await waitFor(() => reject(new Error(testError)));
     const errorMessage = await screen.findByText(testError);
     expect(errorMessage).toBeInTheDocument();
+  });
+  describe('when in read-only mode', () => {
+    beforeEach(() => {
+      setup(true, mockTicket.id);
+    });
+    const getFields = async () => {
+      const firstName = await screen.findByDisplayValue(mockClient.first_name);
+      const petName = await screen.findByDisplayValue(mockAnimal.name);
+      const description = await screen.findByDisplayValue(mockTicket.description);
+      return [firstName, petName, description];
+    };
+    it('should load the ticket from the hook', async () => {
+      //* Arrange
+      // Spot check that client/pet/ticket sections are displaying data
+      // Assumption is each section has its own exhaustive tests for each individual field
+      const fields = await getFields();
+
+      //* Assert
+      expect(mockUseTicketById).toHaveBeenCalledWith(mockTicket.id);
+      fields.forEach((field) => expect(field).toBeInTheDocument());
+    });
+    it('should disable the controls', async () => {
+      //* Arrange
+      // Spot check that client/pet/ticket sections are disabled
+      // Assumption is each section has its own exhaustive tests for each individual field
+      const fields = await getFields();
+
+      //* Assert
+      fields.forEach((field) => expect(field).toBeDisabled());
+    });
   });
 });

--- a/__tests__/src/hooks/useRecentTickets.test.ts
+++ b/__tests__/src/hooks/useRecentTickets.test.ts
@@ -1,0 +1,22 @@
+import { recentTickets } from '@hooks/__mocks__/useRecentTickets';
+import useRecentTickets from '@hooks/useRecentTickets';
+import ClientService from '@services/ClientService';
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('@services/ClientService');
+const mockedClientService = jest.mocked(ClientService);
+
+beforeAll(() => {
+  // Setup mock ClientService
+  mockedClientService.getRecentTickets.mockImplementation(async () => recentTickets);
+});
+
+it('returns the tickets from the db', async () => {
+  //* Act
+  const { result } = renderHook(useRecentTickets);
+  //* Assert
+  await waitFor(() => {
+    expect(mockedClientService.getRecentTickets).toHaveBeenCalled();
+    expect(result.current).toEqual(recentTickets);
+  });
+});

--- a/__tests__/src/hooks/useTicketById.test.ts
+++ b/__tests__/src/hooks/useTicketById.test.ts
@@ -1,0 +1,38 @@
+import { mockAnimal, mockClient, mockTicket } from '@hooks/__mocks__/useTicketById';
+import useTicketById from '@hooks/useTicketById';
+import ClientService from '@services/ClientService';
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('@services/ClientService');
+const mockedClientService = jest.mocked(ClientService);
+
+beforeAll(() => {
+  // Setup mock ClientService
+  const mockGetTicket: typeof ClientService.getTicket = async (id) => {
+    if (id === mockTicket.id) return mockTicket as any;
+    return null;
+  };
+  mockedClientService.getTicket.mockImplementation(mockGetTicket);
+  const mockGetClientByKeyValue: typeof ClientService.getClientByKeyValue = async (key, value) => {
+    if (key === 'id' && value === mockClient.id) return mockClient as any;
+    return null;
+  };
+  mockedClientService.getClientByKeyValue.mockImplementation(mockGetClientByKeyValue);
+  const mockGetAnimalByKeyValue: typeof ClientService.getAnimalByKeyValue = async (key, value) => {
+    if (key === 'id' && value === mockAnimal.id) return mockAnimal as any;
+    return null;
+  };
+  mockedClientService.getAnimalByKeyValue.mockImplementation(mockGetAnimalByKeyValue);
+});
+
+it('returns the ticket, client and pet from the db', async () => {
+  // Arrange
+  const expected = { ticket: mockTicket, client: mockClient, animal: mockAnimal };
+  // Act
+  const { result } = renderHook(useTicketById, { initialProps: mockTicket.id });
+  // Assert
+  await waitFor(() => {
+    expect(mockedClientService.getTicket).toHaveBeenCalledWith(mockTicket.id);
+    expect(result.current).toEqual(expected);
+  });
+});

--- a/__tests__/src/hooks/useTicketById.test.ts
+++ b/__tests__/src/hooks/useTicketById.test.ts
@@ -1,10 +1,13 @@
 import { mockAnimal, mockClient, mockTicket } from '@hooks/__mocks__/useTicketById';
 import useTicketById from '@hooks/useTicketById';
+import AnimalService from '@services/AnimalService';
 import ClientService from '@services/ClientService';
 import { renderHook, waitFor } from '@testing-library/react';
 
 jest.mock('@services/ClientService');
 const mockedClientService = jest.mocked(ClientService);
+jest.mock('@services/AnimalService');
+const mockedAnimalService = jest.mocked(AnimalService);
 
 beforeAll(() => {
   // Setup mock ClientService
@@ -18,11 +21,11 @@ beforeAll(() => {
     return null;
   };
   mockedClientService.getClientByKeyValue.mockImplementation(mockGetClientByKeyValue);
-  const mockGetAnimalByKeyValue: typeof ClientService.getAnimalByKeyValue = async (key, value) => {
+  const mockGetAnimal: typeof AnimalService.get = async (key, value) => {
     if (key === 'id' && value === mockAnimal.id) return mockAnimal as any;
     return null;
   };
-  mockedClientService.getAnimalByKeyValue.mockImplementation(mockGetAnimalByKeyValue);
+  mockedAnimalService.get.mockImplementation(mockGetAnimal);
 });
 
 it('returns the ticket, client and pet from the db', async () => {

--- a/__tests__/src/services/ClientService.test.ts
+++ b/__tests__/src/services/ClientService.test.ts
@@ -40,6 +40,7 @@ jest.mock('@supabase/supabase-js', () => ({
       lte: jest.fn().mockReturnThis(),
       update: jest.fn().mockReturnThis(),
       insert: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
       error: null,
     };
   }),
@@ -92,6 +93,42 @@ describe('ClientService', () => {
       // act & assert
       await expect(ClientService.createTicket(ticket, '', ''))
         .rejects.toThrow();
+    });
+  });
+  describe('static getTicket()', () => {
+    it('returns the ticket from the db', async () => {
+      // Arrange
+      const expectedTicket = { id: '123abc' };
+      mockSupabaseClient.setTestData(expectedTicket);
+      // Act
+      const actualTicket = await ClientService.getTicket(expectedTicket.id);
+      // Assert
+      expect(actualTicket).toBe(expectedTicket);
+    });
+    it('throws errors from the db', async () => {
+      // Arrange
+      const expectedErrorMessage = 'Internal DB Error';
+      mockSupabaseClient.setTestError(new Error(expectedErrorMessage));
+      // Act & Assert
+      await expect(ClientService.getTicket('')).rejects.toThrow(expectedErrorMessage);
+    });
+  });
+  describe('static getRecentTickets()', () => {
+    it('returns recent tickets from the db', async () => {
+      // Arrange
+      const expectedTickets = [{ id: '123abc' }, { id: '456def' }];
+      mockSupabaseClient.setTestData(expectedTickets);
+      // Act
+      const actualTicket = await ClientService.getRecentTickets();
+      // Assert
+      expect(actualTicket).toBe(expectedTickets);
+    });
+    it('throws errors from the db', async () => {
+      // Arrange
+      const expectedErrorMessage = 'Internal DB Error';
+      mockSupabaseClient.setTestError(new Error(expectedErrorMessage));
+      // Act & Assert
+      await expect(ClientService.getRecentTickets()).rejects.toThrow(expectedErrorMessage);
     });
   });
   it.each([

--- a/__tests__/src/services/ClientService.test.ts
+++ b/__tests__/src/services/ClientService.test.ts
@@ -12,6 +12,8 @@ import {
   EditableClientType,
   EditableServiceRequestType,
 } from '@types';
+import { mockTicket } from '@hooks/__mocks__/useTicketById';
+import { recentTickets } from '@hooks/__mocks__/useRecentTickets';
 import ClientService, { clientService } from '../../../src/services/ClientService';
 import supabaseClient from '../../../utils/supabaseClient';
 
@@ -98,7 +100,7 @@ describe('ClientService', () => {
   describe('static getTicket()', () => {
     it('returns the ticket from the db', async () => {
       // Arrange
-      const expectedTicket = { id: '123abc' };
+      const expectedTicket = mockTicket;
       mockSupabaseClient.setTestData(expectedTicket);
       // Act
       const actualTicket = await ClientService.getTicket(expectedTicket.id);
@@ -116,7 +118,7 @@ describe('ClientService', () => {
   describe('static getRecentTickets()', () => {
     it('returns recent tickets from the db', async () => {
       // Arrange
-      const expectedTickets = [{ id: '123abc' }, { id: '456def' }];
+      const expectedTickets = recentTickets;
       mockSupabaseClient.setTestData(expectedTickets);
       // Act
       const actualTicket = await ClientService.getRecentTickets();

--- a/layout/AppMenu.tsx
+++ b/layout/AppMenu.tsx
@@ -23,7 +23,7 @@ interface Item {
 }
 
 function AppMenu() {
-  const [dialog, showDialog] = useState('');
+  const [dialogVisible, setDialogVisible] = useState(false);
   const { user } = useContext(UserContext);
   const { contextPath } = getConfig().publicRuntimeConfig;
   const router = useRouter();
@@ -31,7 +31,7 @@ function AppMenu() {
   const searchParams = useSearchParams();
   const ticketId = searchParams.get('ticket');
   const onClose = () => {
-    showDialog('');
+    setDialogVisible(false);
     const newSearchParams = new URLSearchParams(searchParams.toString());
     newSearchParams.delete('ticket');
     router.push(`${pathname}?${newSearchParams.toString()}`);
@@ -55,7 +55,7 @@ function AppMenu() {
         key: 'newServiceRequest',
         class: 'new-request-icon',
         command: () => {
-          if (!dialog) showDialog('newServiceRequest');
+          if (!dialogVisible) setDialogVisible(true);
         },
       },
       {
@@ -84,7 +84,7 @@ function AppMenu() {
       {/* Modal opening and closing */}
       <ServiceRequestDialog
         ticketId={ticketId}
-        visible={dialog === 'newServiceRequest' || !!ticketId}
+        visible={dialogVisible || !!ticketId}
         onClose={onClose}
       />
     </>

--- a/layout/AppMenu.tsx
+++ b/layout/AppMenu.tsx
@@ -4,6 +4,7 @@ import React, {
 } from 'react';
 import ServiceRequestDialog from '@components/serviceRequest/ServiceRequestDialog';
 import { useRouter } from 'next/router';
+import { usePathname, useSearchParams } from 'next/navigation';
 import AppMenuitem from './AppMenuitem';
 import { MenuProvider } from './context/menucontext';
 import { UserContext } from '../src/context/usercontext';
@@ -23,10 +24,19 @@ interface Item {
 
 function AppMenu() {
   const [dialog, showDialog] = useState('');
-  const onClose = () => showDialog('');
   const { user } = useContext(UserContext);
   const { contextPath } = getConfig().publicRuntimeConfig;
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const ticketId = searchParams.get('ticket');
+  const onClose = () => {
+    showDialog('');
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    newSearchParams.delete('ticket');
+    router.push(`${pathname}?${newSearchParams.toString()}`);
+  };
+
   const models: { items: (Item)[] }[] = [{
     items: [
 
@@ -73,7 +83,8 @@ function AppMenu() {
       </MenuProvider>
       {/* Modal opening and closing */}
       <ServiceRequestDialog
-        visible={dialog === 'newServiceRequest'}
+        ticketId={ticketId}
+        visible={dialog === 'newServiceRequest' || !!ticketId}
         onClose={onClose}
       />
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ import { Button } from 'primereact/button';
 import { Chart } from 'primereact/chart';
 import { Menu } from 'primereact/menu';
 import { useContext, useEffect, useRef } from 'react';
+import RecentTickets from '@components/RecentTickets';
 import { LayoutContext } from '../layout/context/layoutcontext';
 
 const lineData = {
@@ -188,7 +189,7 @@ const Dashboard: React.FC = () => {
       <div className="col-12 xl:col-6">
         <div className="card">
           <h5>Recent Client Tickets</h5>
-
+          <RecentTickets />
         </div>
         <div className="card">
           <div className="flex justify-content-between align-items-center mb-5">
@@ -315,7 +316,7 @@ const Dashboard: React.FC = () => {
                 <span className="text-700">
                   {' '}
                   has purchased a blue t-shirt for
-                                  {' '}
+                  {' '}
                   <span className="text-blue-500">79$</span>
                 </span>
               </span>
@@ -345,7 +346,7 @@ const Dashboard: React.FC = () => {
                 <span className="text-700">
                   {' '}
                   has purchased a black jacket for
-                                  {' '}
+                  {' '}
                   <span className="text-blue-500">59$</span>
                 </span>
               </span>

--- a/src/components/RecentTickets.tsx
+++ b/src/components/RecentTickets.tsx
@@ -1,0 +1,21 @@
+// TODO Remove this sprint demo component
+import useRecentTickets from '@hooks/useRecentTickets';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function RecentTickets() {
+  const pathname = usePathname();
+  const tickets = useRecentTickets();
+  return (
+    <ul>
+      {tickets.map(({ id, description, created_at }) => (
+        <li key={id}>
+          <Link href={`${pathname}?ticket=${id}`}>
+            <em>{new Date(created_at).toLocaleDateString()}</em>
+            <span className="ml-3 text-lg">{description}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/serviceRequest/ServiceRequestDialog.tsx
+++ b/src/components/serviceRequest/ServiceRequestDialog.tsx
@@ -11,6 +11,8 @@ import {
   serviceInfoReducer, defaultServiceInformation, ServiceInfoActionType, ServiceInformationProvider,
 } from '@context/serviceRequest/serviceInformationContext';
 import { clientService } from 'src/services/ClientService';
+import { ServiceRequestType } from '@types';
+import useTicketById from '@hooks/useTicketById';
 import ClientInformationSection from './ClientInformationSection';
 import PetInformationSection from './PetInformationSection';
 import ServiceInformationSection from './ServiceInformationSection';
@@ -26,17 +28,75 @@ interface ServiceRequestDialogProps {
   visible: boolean
   /** Callback for the hide dialog button */
   onClose: () => void
+  /** The ID of the ticket */
+  ticketId: ServiceRequestType['id']
 }
 
 /**
  *
  * @returns A dialog with a controlled form for creating a service request.
  */
-function ServiceRequestDialog(props: ServiceRequestDialogProps) {
-  const { visible, onClose } = props;
+function ServiceRequestDialog({ visible, onClose, ticketId }: ServiceRequestDialogProps) {
+  const {
+    disabled, readOnly, close, save, message, showDialog, hideDialog, client, pet, ticket,
+    clientInformationDispatch, petInformationDispatch, serviceInformationDispatch,
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  } = useServiceRequestDialogState({ visible, onClose, ticketId });
+
+  const dialogFooter = (
+    <FormConfirmationButtons
+      disabled={disabled}
+      onCancelClicked={close}
+      onSaveClicked={save}
+      saving={disabled}
+    />
+  );
+
+  return (
+    <Dialog
+      data-testid="serviceRequestDialog"
+      visible={showDialog}
+      style={{ width: '850px' }}
+      header={serviceRequestLabels.FormHeader}
+      modal
+      footer={!readOnly && dialogFooter}
+      onHide={hideDialog}
+    >
+      <div className="col-12 md:col-12">
+        <div className="card">
+          {message && (
+            <h3 className="text-red-500">
+              {message}
+            </h3>
+          )}
+          <ClientInformationProvider
+            state={client}
+            dispatch={clientInformationDispatch}
+          >
+            <ClientInformationSection disabled={disabled} />
+          </ClientInformationProvider>
+          <PetInformationProvider state={pet} dispatch={petInformationDispatch}>
+            <PetInformationSection disabled={disabled} />
+          </PetInformationProvider>
+          <ServiceInformationProvider
+            state={ticket}
+            dispatch={serviceInformationDispatch}
+          >
+            <ServiceInformationSection disabled={disabled} />
+          </ServiceInformationProvider>
+        </div>
+
+      </div>
+    </Dialog>
+  );
+}
+
+function useServiceRequestDialogState({ visible, onClose, ticketId }: ServiceRequestDialogProps) {
   const [showDialog, setShowDialog] = useState(false);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
+  const [readOnly, setReadOnly] = useState(false);
+  const { client: savedClient, animal: savedAnimal, ticket: savedTicket } = useTicketById(ticketId);
 
   useEffect(() => {
     setShowDialog(visible);
@@ -48,16 +108,29 @@ function ServiceRequestDialog(props: ServiceRequestDialogProps) {
 
   //* Get state and dispatchers for the from sections
   const [
-    clientInformationState, clientInformationDispatch,
+    newClient, clientInformationDispatch,
   ] = useReducer(clientInfoReducer, defaultClientInformation);
 
   const [
-    petInformationState, petInformationDispatch,
+    newPet, petInformationDispatch,
   ] = useReducer(petInfoReducer, defaultPetInformation);
 
   const [
-    serviceInformationState, serviceInformationDispatch,
+    newTicket, serviceInformationDispatch,
   ] = useReducer(serviceInfoReducer, defaultServiceInformation);
+
+  const dataState = { client: newClient, pet: newPet, ticket: newTicket };
+  if (ticketId) {
+    if (!readOnly) setReadOnly(true);
+    dataState.client = savedClient;
+    dataState.pet = savedAnimal;
+    dataState.ticket = savedTicket;
+  } else {
+    if (readOnly) setReadOnly(false);
+    dataState.client = newClient;
+    dataState.pet = newPet;
+    dataState.ticket = newTicket;
+  }
 
   const close = () => {
     //* Clear form data
@@ -74,9 +147,9 @@ function ServiceRequestDialog(props: ServiceRequestDialogProps) {
     // TODO add error handling scenario
     try {
       await clientService.newRequest(
-        serviceInformationState,
-        clientInformationState,
-        petInformationState,
+        newTicket,
+        newClient,
+        newPet,
       );
       close();
     } catch (e) {
@@ -86,52 +159,19 @@ function ServiceRequestDialog(props: ServiceRequestDialogProps) {
     }
   };
 
-  const dialogFooter = (
-    <FormConfirmationButtons
-      disabled={busy}
-      onCancelClicked={close}
-      onSaveClicked={save}
-      saving={busy}
-    />
-  );
-
-  return (
-    <Dialog
-      data-testid="serviceRequestDialog"
-      visible={showDialog}
-      style={{ width: '850px' }}
-      header={serviceRequestLabels.FormHeader}
-      modal
-      footer={dialogFooter}
-      onHide={hideDialog}
-    >
-      <div className="col-12 md:col-12">
-        <div className="card">
-          {message && (
-            <h3 className="text-red-500">
-              {message}
-            </h3>
-          )}
-          <ClientInformationProvider
-            state={clientInformationState}
-            dispatch={clientInformationDispatch}
-          >
-            <ClientInformationSection disabled={busy} />
-          </ClientInformationProvider>
-          <PetInformationProvider state={petInformationState} dispatch={petInformationDispatch}>
-            <PetInformationSection disabled={busy} />
-          </PetInformationProvider>
-          <ServiceInformationProvider
-            state={serviceInformationState}
-            dispatch={serviceInformationDispatch}
-          >
-            <ServiceInformationSection disabled={busy} />
-          </ServiceInformationProvider>
-        </div>
-
-      </div>
-    </Dialog>
-  );
+  return {
+    readOnly,
+    disabled: readOnly || busy,
+    close,
+    save,
+    showDialog,
+    hideDialog,
+    message,
+    clientInformationDispatch,
+    petInformationDispatch,
+    serviceInformationDispatch,
+    ...dataState,
+  };
 }
 
 export default ServiceRequestDialog;

--- a/src/hooks/__mocks__/useRecentTickets.ts
+++ b/src/hooks/__mocks__/useRecentTickets.ts
@@ -1,0 +1,10 @@
+import type { ServiceRequestType } from '@types';
+import { mockTicket } from '@hooks/__mocks__/useTicketById';
+
+export const recentTickets = [
+  mockTicket,
+  { ...mockTicket, id: '147xyz' },
+];
+const useRecentTickets: (id: string) => ServiceRequestType[] = jest.fn(() => recentTickets);
+
+export default useRecentTickets;

--- a/src/hooks/__mocks__/useTeamMembers.ts
+++ b/src/hooks/__mocks__/useTeamMembers.ts
@@ -1,5 +1,5 @@
-export const john = { value: 'abc', label: 'john@test.digitalseattle.org' };
-export const jane = { value: 'xyz', label: 'jane@test.digitalseattle.org' };
+export const john = { id: 'j456', value: 'abc', label: 'john@test.digitalseattle.org' };
+export const jane = { id: 'j123', value: 'xyz', label: 'jane@test.digitalseattle.org' };
 export const teamMembers = [jane, john];
 export default function useTeamMembers() {
   return teamMembers;

--- a/src/hooks/__mocks__/useTicketById.ts
+++ b/src/hooks/__mocks__/useTicketById.ts
@@ -1,0 +1,39 @@
+import { data } from '@hooks/__mocks__/useAppConstants';
+import { john } from '@hooks/__mocks__/useTeamMembers';
+import type { AnimalType, ClientType, ServiceRequestType } from '@types';
+import type { UseTicketByIdState } from '@hooks/useTicketById';
+
+export const mockClient: ClientType = {
+  id: '456def',
+  first_name: 'John',
+  last_name: 'Smith',
+  email: 'j.smith@test.openseattle.org',
+  phone: '555-555-5555',
+  zip_code: '12345',
+};
+export const mockAnimal: AnimalType = {
+  id: '789ghi',
+  client_id: mockClient.id,
+  name: 'Sparky',
+  age: 5,
+  weight: 10,
+  species_id: data.species[0].id,
+};
+export const mockTicket: ServiceRequestType = {
+  id: '123abc',
+  client_id: mockClient.id,
+  pet_id: mockAnimal.id,
+  service_category_id: data.category[0].id,
+  request_source_id: data.source[0].id,
+  team_member_id: john.id,
+  log_id: '',
+  description: 'Cleaning service',
+  created_at: '',
+};
+const useTicketById: (id: string) => UseTicketByIdState = jest.fn(() => ({
+  ticket: mockTicket,
+  client: mockClient,
+  animal: mockAnimal,
+}));
+
+export default useTicketById;

--- a/src/hooks/useRecentTickets.ts
+++ b/src/hooks/useRecentTickets.ts
@@ -1,18 +1,20 @@
 // TODO Remove this sprint Demo hook
 import { ServiceRequestType } from '@types';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import ClientService from 'src/services/ClientService';
 
 export default function useRecentTickets() {
   const [tickets, setTickets] = useState<ServiceRequestType[]>([]);
-
+  // Hack:  using url change to trigger to get recent tickets
+  const params = useSearchParams();
   useEffect(() => {
     const getTickets = async () => {
       const data = await ClientService.getRecentTickets();
       setTickets(data);
     };
     getTickets();
-  }, []);
+  }, [params]);
 
   return tickets;
 }

--- a/src/hooks/useRecentTickets.ts
+++ b/src/hooks/useRecentTickets.ts
@@ -12,7 +12,7 @@ export default function useRecentTickets() {
       setTickets(data);
     };
     getTickets();
-  });
+  }, []);
 
   return tickets;
 }

--- a/src/hooks/useRecentTickets.ts
+++ b/src/hooks/useRecentTickets.ts
@@ -1,0 +1,18 @@
+// TODO Remove this sprint Demo hook
+import { ServiceRequestType } from '@types';
+import { useEffect, useState } from 'react';
+import ClientService from 'src/services/ClientService';
+
+export default function useRecentTickets() {
+  const [tickets, setTickets] = useState<ServiceRequestType[]>([]);
+
+  useEffect(() => {
+    const getTickets = async () => {
+      const data = await ClientService.getRecentTickets();
+      setTickets(data);
+    };
+    getTickets();
+  });
+
+  return tickets;
+}

--- a/src/hooks/useTicketById.ts
+++ b/src/hooks/useTicketById.ts
@@ -5,12 +5,13 @@ import { EditableAnimalType, EditableClientType, EditableServiceRequestType } fr
 import { useEffect, useState } from 'react';
 import ClientService from 'src/services/ClientService';
 
+export type UseTicketByIdState = {
+  client: EditableClientType,
+  animal: EditableAnimalType,
+  ticket: EditableServiceRequestType
+};
 export default function useTicketById(ticketId: string) {
-  const [state, setState] = useState<{
-    client: EditableClientType,
-    animal: EditableAnimalType,
-    ticket: EditableServiceRequestType
-  }>({
+  const [state, setState] = useState<UseTicketByIdState>({
     client: defaultClientInformation,
     animal: defaultPetInformation,
     ticket: defaultServiceInformation,

--- a/src/hooks/useTicketById.ts
+++ b/src/hooks/useTicketById.ts
@@ -1,0 +1,38 @@
+import { defaultClientInformation } from '@context/serviceRequest/clientInformationContext';
+import { defaultPetInformation } from '@context/serviceRequest/petInformationContext';
+import { defaultServiceInformation } from '@context/serviceRequest/serviceInformationContext';
+import { EditableAnimalType, EditableClientType, EditableServiceRequestType } from '@types';
+import { useEffect, useState } from 'react';
+import ClientService from 'src/services/ClientService';
+
+export default function useTicketById(ticketId: string) {
+  const [state, setState] = useState<{
+    client: EditableClientType,
+    animal: EditableAnimalType,
+    ticket: EditableServiceRequestType
+  }>({
+    client: defaultClientInformation,
+    animal: defaultPetInformation,
+    ticket: defaultServiceInformation,
+  });
+
+  useEffect(() => {
+    const getTicket = async () => {
+      const ticket = await ClientService.getTicket(ticketId);
+      /**
+       * TODO consider using Promise.allSettled
+       * If one of the promises passed to Promise.all() fails,
+       * then all in-progress promises are stopped and an error is thrown.
+       * However using .allSettled() would allow us to gracefully handle individual query failures.
+       */
+      const [client, animal] = await Promise.all([
+        ClientService.getClientByKeyValue('id', ticket.client_id),
+        ClientService.getAnimalByKeyValue('id', ticket.pet_id),
+      ]);
+      setState({ ticket, client, animal });
+    };
+    if (ticketId) getTicket();
+  }, [ticketId]);
+
+  return state;
+}

--- a/src/hooks/useTicketById.ts
+++ b/src/hooks/useTicketById.ts
@@ -1,6 +1,7 @@
 import { defaultClientInformation } from '@context/serviceRequest/clientInformationContext';
 import { defaultPetInformation } from '@context/serviceRequest/petInformationContext';
 import { defaultServiceInformation } from '@context/serviceRequest/serviceInformationContext';
+import AnimalService from '@services/AnimalService';
 import { EditableAnimalType, EditableClientType, EditableServiceRequestType } from '@types';
 import { useEffect, useState } from 'react';
 import ClientService from 'src/services/ClientService';
@@ -28,7 +29,7 @@ export default function useTicketById(ticketId: string) {
        */
       const [client, animal] = await Promise.all([
         ClientService.getClientByKeyValue('id', ticket.client_id),
-        ClientService.getAnimalByKeyValue('id', ticket.pet_id),
+        AnimalService.get('id', ticket.pet_id),
       ]);
       setState({ ticket, client, animal });
     };

--- a/src/services/AnimalService.ts
+++ b/src/services/AnimalService.ts
@@ -3,6 +3,8 @@
 /* eslint-disable max-classes-per-file */
 import getConfig from 'next/config';
 import { v4 as uuidv4 } from 'uuid';
+import supabaseClient from 'utils/supabaseClient';
+import { AnimalType } from '@types';
 import { NewClientRequest } from './ClientService';
 
 enum RequestType {
@@ -125,8 +127,26 @@ class AnimalService {
   // TODO remove when in prod
   tickets: ClientTicket[] = [];
 
-  constructor() {
-    this.contextPath = getConfig().publicRuntimeConfig.contextPath;
+  static async get<T extends keyof AnimalType>(
+    key: T,
+    value: AnimalType[T],
+  ): Promise<AnimalType> {
+    const { data, error } = await supabaseClient
+      .from('pets')
+      .select('*')
+      .eq(key, value)
+      .maybeSingle();
+
+    if (error) {
+      console.log(`ERROR IN GET PET BY ${key}:`, error);
+      // Disabled because error is already an Error object
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw error;
+    }
+
+    if (!data) throw new Error(`No pet found with the provided ${key}`);
+
+    return data;
   }
 
   newRequest(request: NewClientRequest): Promise<ClientTicket> {
@@ -163,6 +183,7 @@ class AnimalService {
 }
 
 const animalService = new AnimalService();
+export default AnimalService;
 export {
   NewAnimalRecord, ClientTicket, TicketType, animalService,
 };

--- a/src/services/ClientService.ts
+++ b/src/services/ClientService.ts
@@ -266,12 +266,12 @@ class ClientService {
     ClientService.throwIfInvalidInput('client', client);
     const {
 
-      first_name, last_name, email, phone,
+      first_name, last_name, email, phone, zip_code,
     } = client;
     const { data: newClient, error } = await supabaseClient
       .from('clients')
       .insert([{
-        first_name, last_name, email, phone,
+        first_name, last_name, email, phone, zip_code,
       }])
       .select()
       .single();
@@ -287,6 +287,8 @@ class ClientService {
         name: animal.name,
         species_id: animal.species_id,
         client_id: clientId,
+        age: animal.age,
+        weight: animal.weight,
       }])
       .select()
       .single();

--- a/src/services/ClientService.ts
+++ b/src/services/ClientService.ts
@@ -316,6 +316,26 @@ class ClientService {
     return newTicket;
   }
 
+  static async getTicket(ticketId: ServiceRequestType['id']) {
+    const { data: ticket, error } = await supabaseClient
+      .from('service_requests')
+      .select()
+      .eq('id', ticketId)
+      .single();
+    if (error) throw new Error(`${error.message}`);
+    return ticket;
+  }
+
+  static async getRecentTickets() {
+    const { data: tickets, error } = await supabaseClient
+      .from('service_requests')
+      .select()
+      .order('created_at', { ascending: false })
+      .limit(10);
+    if (error) throw new Error(`${error.message}`);
+    return tickets;
+  }
+
   async getClientByEmail(email: string): Promise<ClientType> {
     try {
       const { data, error } = await supabaseClient
@@ -330,6 +350,54 @@ class ClientService {
       }
 
       if (!data) throw new Error('No client found with this email');
+
+      return data;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  static async getClientByKeyValue<T extends keyof ClientType>(
+    key: T,
+    value: ClientType[T],
+  ): Promise<ClientType> {
+    try {
+      const { data, error } = await supabaseClient
+        .from('clients')
+        .select('*')
+        .eq(key, value)
+        .maybeSingle();
+
+      if (error) {
+        console.log(`ERROR IN GET CLIENT BY ${key}:`, error);
+        throw error;
+      }
+
+      if (!data) throw new Error(`No client found with the provided ${key}`);
+
+      return data;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  static async getAnimalByKeyValue<T extends keyof AnimalType>(
+    key: T,
+    value: AnimalType[T],
+  ): Promise<AnimalType> {
+    try {
+      const { data, error } = await supabaseClient
+        .from('pets')
+        .select('*')
+        .eq(key, value)
+        .maybeSingle();
+
+      if (error) {
+        console.log(`ERROR IN GET PET BY ${key}:`, error);
+        throw error;
+      }
+
+      if (!data) throw new Error(`No pet found with the provided ${key}`);
 
       return data;
     } catch (error) {
@@ -396,6 +464,29 @@ class ClientService {
       .select();
     if (error) throw new Error(error.message);
     return teamMembers;
+  }
+
+  static async getTeamMemberById(
+    id: TeamMemberType['id'],
+  ): Promise<TeamMemberType> {
+    try {
+      const { data, error } = await supabaseClient
+        .from('team_members')
+        .select('*')
+        .eq('id', id)
+        .maybeSingle();
+
+      if (error) {
+        console.log('ERROR IN GET TEAMMEMBER BY ID:', error);
+        throw error;
+      }
+
+      if (!data) throw new Error('No team member found with the provided ID');
+
+      return data;
+    } catch (error) {
+      throw error;
+    }
   }
 }
 

--- a/src/services/ClientService.ts
+++ b/src/services/ClientService.ts
@@ -383,30 +383,6 @@ class ClientService {
     }
   }
 
-  static async getAnimalByKeyValue<T extends keyof AnimalType>(
-    key: T,
-    value: AnimalType[T],
-  ): Promise<AnimalType> {
-    try {
-      const { data, error } = await supabaseClient
-        .from('pets')
-        .select('*')
-        .eq(key, value)
-        .maybeSingle();
-
-      if (error) {
-        console.log(`ERROR IN GET PET BY ${key}:`, error);
-        throw error;
-      }
-
-      if (!data) throw new Error(`No pet found with the provided ${key}`);
-
-      return data;
-    } catch (error) {
-      throw error;
-    }
-  }
-
   getTicket(id: string): Promise<ClientTicket> {
     return Promise.resolve(this.tickets.find((t) => t.ticketNo == id));
   }

--- a/src/services/ClientService.ts
+++ b/src/services/ClientService.ts
@@ -465,29 +465,6 @@ class ClientService {
     if (error) throw new Error(error.message);
     return teamMembers;
   }
-
-  static async getTeamMemberById(
-    id: TeamMemberType['id'],
-  ): Promise<TeamMemberType> {
-    try {
-      const { data, error } = await supabaseClient
-        .from('team_members')
-        .select('*')
-        .eq('id', id)
-        .maybeSingle();
-
-      if (error) {
-        console.log('ERROR IN GET TEAMMEMBER BY ID:', error);
-        throw error;
-      }
-
-      if (!data) throw new Error('No team member found with the provided ID');
-
-      return data;
-    } catch (error) {
-      throw error;
-    }
-  }
 }
 
 const clientService = new ClientService();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -8,3 +8,8 @@ values
   ('Phone Call', 'phone call', 'source', TRUE, now(), now()),
   ('Surgery', 'surgery', 'category', TRUE, now(), now()),
   ('Vaccination', 'vaccination', 'category', TRUE, now(), now());
+
+insert into app_constants
+  (first_name, last_name, email)
+values
+  ('admin', 'admin', 'example@example.com');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -3,4 +3,8 @@ insert into app_constants
 values
   ('Cat', 'cat', 'species', TRUE, now(), now()),
   ('Reptile', 'reptile', 'species', TRUE, now(), now()),
-  ('Dog', 'dog', 'species', TRUE, now(), now());
+  ('Dog', 'dog', 'species', TRUE, now(), now()),
+  ('Email', 'email', 'source', TRUE, now(), now()),
+  ('Phone Call', 'phone call', 'source', TRUE, now(), now()),
+  ('Surgery', 'surgery', 'category', TRUE, now(), now()),
+  ('Vaccination', 'vaccination', 'category', TRUE, now(), now());

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -9,7 +9,7 @@ values
   ('Surgery', 'surgery', 'category', TRUE, now(), now()),
   ('Vaccination', 'vaccination', 'category', TRUE, now(), now());
 
-insert into app_constants
+insert into team_members
   (first_name, last_name, email)
 values
   ('admin', 'admin', 'example@example.com');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "paths": {
+      "@services/*": [
+        "src/services/*"
+      ],
       "@components/*": [
         "src/components/*"
       ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the ability to open a service request in the input form dialog by using the ticket it in a URL search param.

App constants seed data was also added to make it easier to set up the application.


## Related Tickets & Documents
[1.2.2.0 Wire up input form for saving to the database](https://projects.digitalaidseattle.org/project-tasks-details?recordId=recm4ng99AfweJQak)
[1.2.2.5 Input form Services](https://projects.digitalaidseattle.org/project-tasks-details?recordId=recwaTG9vy9WaSksT)
[1.2.2.21 Team member lookup hook](https://projects.digitalaidseattle.org/project-tasks-details?recordId=recsHrpLhSMiMPEkw)


## QA Instructions, Screenshots, Recordings

_With a working environment_
1. Create a new request using the New Request menu in the top nav bar
2. After saving the request, the request appears under Recent Tickets on the dashboard
3. Open the ticket you created and verify the information appears correctly

### UI accessibility checklist

- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Color contrast tested?

## Added/updated tests?
_We are aiming for 100% statement coverage._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Done and done](https://media1.tenor.com/m/93OUVuCIk6MAAAAC/done-and-done-spongebob.gif)