### PR TITLE
enforce LF line break character across diff OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
        - If the change needs to be large, set up a meeting with reviewers to walk through the code.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description
Different operating systems use different characters as line endings (CLRF vs LF vs CL). Devs working from windows will have different line endings that devs on Unix. So this is one of the few config options that will stop git from converting/tracking new line characters which would cause empty commits basically and litter the commit history.
The reason LF is chosen as the line ending default char for this repository is that the repository is already written with LF, I'm one of the few devs not working with LF and git tried to auto convert it to CLRF and commit those changes. This will help future windows devs not have to deal with this problem.

## Related Tickets & Documents

[user story](https://projects.digitalaidseattle.org/project-tasks-details?recordId=recealmIIGiUH3bMS)

## [optional] Which Seattle Humane animal would you like to dedicate this PR to?

Lucy 

 ![image](https://github.com/digitalaidseattle/seattle-humane-app/assets/8835499/b8e6f651-cf8a-4e2d-8296-4f3fc65af3cc)