### PR TITLE
Exclude binary files from git EOL settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text eol=lf
+# Binary files.
+*.png binary
+*.jpg binary
+*.ico binary
+*.woff* binary


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Merge changes for images and font files were not possible to get rid of. `git reset --hard HEAD` would result in the files still showing with merge changes.

Solution from:
https://stackoverflow.com/a/52694438/25657391

## Added/updated tests?
_We are aiming for 100% statement coverage._

- [ ] Yes
- [x] No, and this is why: _not a functional change_
- [ ] I need help with writing tests

